### PR TITLE
Project.toml, test and optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 test/SmallExample.jld2
+Manifest.toml
+*~
 # Windows thumbnail cache files
 Thumbs.db
 ehthumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+test/SmallExample.jld2
 # Windows thumbnail cache files
 Thumbs.db
 ehthumbs.db

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,18 @@
+name = "DINEOF"
+uuid = "124844e3-9c1d-560a-894a-ce64a2d37801"
+keywords = ["DINEOF"]
+
+[deps]
+Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[extras]
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["JLD2", "FileIO", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,31 @@
+using DINEOF
+using JLD2
+using Statistics
+using FileIO
+using Random
+using Test
+
+#=
+# the small example is created using the example file from
+https://github.com/aida-alvera/DINEOF/blob/master/SmallExample/seacoos2005.avhrr
+
+  Random.seed!(1234); XA,offset,U,S,V,cvEOF,cvarray,errmap,musquare = @time DINEOF.DINEOFrun(X; errormap = false);
+  FileIO.save("testdata.jld2","X",X,"XA",XA,"cvarray",cvarray);
+=#
+
+SmallExampleFile = joinpath(dirname(@__FILE__),"SmallExample.jld2")
+
+if !isfile(SmallExampleFile)
+    download("https://dox.ulg.ac.be/index.php/s/Vr1YNtmz16mRVkP/download",SmallExampleFile)
+end
+
+ref = FileIO.load(SmallExampleFile)
+X = ref["X"]
+
+Random.seed!(1234);
+XA,offset,U,S,V,cvEOF,cvarray,errmap,musquare = @time DINEOF.DINEOFrun(X; errormap = false)
+
+difference = (XA - ref["XA"]);
+
+@test sqrt(mean(difference[isfinite.(difference)].^2)) ≈ 0. atol=1e-7
+@test cvarray ≈ ref["cvarray"]


### PR DESCRIPTION
I ported the DINEOF "Small Example" to DINEOF.jl and with the optimization, the run-time of the small example is reduce from 92 seconds to 7 seconds!

In turns-out that there are some allocation in this statement:
```
zz=SVU[i:i,:]*diagm(SVS)*(SVV[j:j,:])' 
```
In particular `diagm`: allocation of a diagonal matrix, `SVU[i:i,:]` allocation of a sub-vector (which could be avoided using `view(SVU,i:i,:)`). In the attached PR, all these allocation are avoided using a for-loop.

The run-time is now comparable to the Fortran version which uses 10 seconds for the small example.
(error maps are not tested or benchmarked.)

Strange observation: Julia and DINEOF-Fortran uses 400 % of CPU time due to the threaded OpenBLAS library. If the number of threads is forced to 1 (`export OPENBLAS_NUM_THREADS=1`), the runtime is reduce in both cases: to 4 seconds for `DINEOF.jl` and to 8 seconds to `DINEOF`-Fortran.
